### PR TITLE
Make deboost.context proper C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,5 +69,6 @@ target_include_directories(fcontext
 
 set_target_properties(fcontext PROPERTIES FOLDER Deps ${IOS_GENERAL_PROPERTIES})
 
-#install(TARGETS fcontext DESTINATION lib)
-#install(FILES ${HEADER} DESTINATION include/fcontext)
+install(TARGETS fcontext DESTINATION lib)
+install(FILES ${HEADER} DESTINATION include/fcontext)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 add_definitions(-DBOOST_CONTEXT_EXPORT=)
 
 set(HEADER "include/fcontext/fcontext.h")
-set(SOURCES "source/stack.cpp")
+set(SOURCES "source/stack.c")
 
 # OS
 if (APPLE)
@@ -63,7 +63,7 @@ set(ASM_SOURCES "asm/make_${CPU_ARCH}_${ASM_EXT}"
                 "asm/ontop_${CPU_ARCH}_${ASM_EXT}")
 
 add_library(fcontext STATIC ${SOURCES} ${ASM_SOURCES})
-target_include_directories(fcontext 
+target_include_directories(fcontext
     PRIVATE include/fcontext
     INTERFACE include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # PROJECT: fcontext
 cmake_minimum_required(VERSION 3.0)
-project(fcontext)
+project(fcontext C)
 
 if (NOT CMAKE_MODULE_PATH)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/include/fcontext/fcontext.h
+++ b/include/fcontext/fcontext.h
@@ -8,17 +8,17 @@ extern "C" {
 #endif
     typedef void* fcontext_t;
 
-    struct fcontext_transfer_t
+    typedef struct
     {
         fcontext_t ctx;
         void* data;
-    };
+    } fcontext_transfer_t;
 
-    struct fcontext_stack_t
+    typedef struct
     {
         void* sptr;
         size_t ssize;
-    };
+    } fcontext_stack_t;
 
     /**
      * Callback definition for context (coroutine)
@@ -40,9 +40,9 @@ extern "C" {
      */
     fcontext_t make_fcontext(void * sp, size_t size, pfn_fcontext corofn);
 
-    fcontext_transfer_t ontop_fcontext(fcontext_t const to, void * vp, fcontext_transfer_t(*fn)(fcontext_transfer_t));   
+    fcontext_transfer_t ontop_fcontext(fcontext_t const to, void * vp, fcontext_transfer_t(*fn)(fcontext_transfer_t));
 
-    fcontext_stack_t create_fcontext_stack(size_t size = 0);
+    fcontext_stack_t create_fcontext_stack(size_t size);
     void destroy_fcontext_stack(fcontext_stack_t* s);
 
 #ifdef __cplusplus

--- a/source/stack.c
+++ b/source/stack.c
@@ -80,7 +80,7 @@ static size_t getMinSize()
 
 static size_t getMaxSize()
 {
-    rlimit limit;
+    struct rlimit limit;
     getrlimit(RLIMIT_STACK, &limit);
 
     return (size_t)limit.rlim_max;
@@ -112,7 +112,7 @@ fcontext_stack_t create_fcontext_stack(size_t size)
     if (size > maxsz)
         size = maxsz;
 
-    pages = (size_t)floorf(float(size) / float(getPageSize()));
+    pages = (size_t)floorf((float)size/(float)getPageSize());
     assert(pages >= 2);     /* at least two pages must fit into stack (one page is guard-page) */
 
     size_ = pages * getPageSize();

--- a/test/test_fcontext.c
+++ b/test/test_fcontext.c
@@ -5,20 +5,19 @@
 # include <time.h>
 #endif
 
-#include <cstdio>
-
-#include "fcontext/fcontext.h"
+#include <stdio.h>
+#include <fcontext/fcontext.h>
 
 fcontext_t ctx;
 fcontext_t ctx2;
 
-inline void sleep(uint32_t _ms)
+static inline void  fsleep(uint32_t _ms)
 {
 #ifdef _WIN32
     Sleep(_ms);
 #else
-    timespec req = { (time_t)_ms / 1000, (long)((_ms % 1000) * 1000000) };
-    timespec rem = { 0, 0 };
+    struct timespec req = { (time_t)_ms / 1000, (long)((_ms % 1000) * 1000000) };
+    struct timespec rem = { 0, 0 };
     nanosleep(&req, &rem);
 #endif
 }
@@ -26,26 +25,26 @@ inline void sleep(uint32_t _ms)
 static void doo(fcontext_transfer_t t)
 {
     puts("DOO");
-    sleep(1000);
+    fsleep(1000);
     jump_fcontext(t.ctx, NULL);
 }
 
 static void foo(fcontext_transfer_t t)
 {
     puts("FOO");
-    sleep(1000);
+    fsleep(1000);
     jump_fcontext(ctx2, NULL);
     puts("FOO 2");
-    sleep(1000);
+    fsleep(1000);
     jump_fcontext(t.ctx, NULL);
 }
 
 int main()
 {
-    fcontext_stack_t s = create_fcontext_stack(16 * 1024);
-    fcontext_stack_t s2 = create_fcontext_stack();
+    fcontext_stack_t s  = create_fcontext_stack(16 * 1024);
+    fcontext_stack_t s2 = create_fcontext_stack(0);
 
-    ctx = make_fcontext(s.sptr, s.ssize, foo);
+    ctx  = make_fcontext(s.sptr, s.ssize, foo);
     ctx2 = make_fcontext(s2.sptr, s2.ssize, doo);
 
     jump_fcontext(ctx, NULL);


### PR DESCRIPTION
I made changes to `CMakeLists.txt` and the header so that you don't need a C++ compiler to build and use the project. I also uncommented the "install" lines in `CMakeLists.txt` for my purposes.

I made a pull request, in case you're interested :)