### PR TITLE
Update for cmake v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 .build
+build
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # PROJECT: fcontext
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 project(fcontext C)
 
 option(BUILD_TEST "build test app" 0)


### PR DESCRIPTION
The recently released CMake v4 removed support for earlier versions specified by `cmake_minimum_version`.

This is causing build failures in projects that use deboost.context, such as [NLE](https://github.com/heiner/nle) and [MiniHack](https://github.com/samvelyan/minihack).

This PR updates the CMakeLists.txt to a supported version and adds a minor edit to the .gitignore file.